### PR TITLE
Update comparison table for MOCO

### DIFF
--- a/docs/compare.md
+++ b/docs/compare.md
@@ -22,51 +22,51 @@ There are multiple ways to deploy and manage MySQL in Kubernetes. Here we will f
 
 The review of generic features, such as supported MySQL versions, open source models and more.
 
-| Feature/Product        | Percona Operator for MySQL  (based on PXC) | Percona Operator for MySQL (based on PS) | Bitpoke MySQL Operator |      Moco      | Oracle MySQL Operator |    Vitess      |
-|------------------------|:------------------------------------------:|:----------------------------------------:|:----------------------:|:--------------:|:---------------------:|:--------------:|
-| Open source model      |                 Apache 2.0                 |                Apache 2.0                |       Apache 2.0       |   Apache 2.0   |       Apache 2.0      |   Apache 2.0   |
-| MySQL versions         |                  5.7, 8.0                  |                    8.0                   |           5.7          |       8.0      |          8.0          |    5.7, 8.0    |
-| Kubernetes conformance |         Various versions are tested        |        Various versions are tested       |     Not guaranteed     | Not guaranteed |     Not guaranteed    | Not guaranteed |
-| Paid support           |             :heavy_check_mark:             |            :heavy_check_mark:            |     :no_entry_sign:    | :no_entry_sign:|  :heavy_check_mark:   | :no_entry_sign:|
+| Feature/Product        | Percona Operator for MySQL  (based on PXC) | Percona Operator for MySQL (based on PS) | Bitpoke MySQL Operator |             Moco             | Oracle MySQL Operator |     Vitess      |
+| ---------------------- | :----------------------------------------: | :--------------------------------------: | :--------------------: | :--------------------------: | :-------------------: | :-------------: |
+| Open source model      |                 Apache 2.0                 |                Apache 2.0                |       Apache 2.0       |          Apache 2.0          |      Apache 2.0       |   Apache 2.0    |
+| MySQL versions         |                  5.7, 8.0                  |                   8.0                    |          5.7           |             8.0              |          8.0          |    5.7, 8.0     |
+| Kubernetes conformance |        Various versions are tested         |       Various versions are tested        |     Not guaranteed     | Latest 3 versions are tested |                       | Not guaranteed  |
+| Paid support           |             :heavy_check_mark:             |            :heavy_check_mark:            |    :no_entry_sign:     |       :no_entry_sign:        |  :heavy_check_mark:   | :no_entry_sign: |
 
 ## MySQL Topologies
 
 Focus on replication capabilities and proxies integrations.
 
-| Feature/Product          | Percona Operator for MySQL  (based on PXC) | Percona Operator for MySQL (based on PS) | Bitpoke MySQL Operator |      Moco     | Oracle MySQL Operator |    Vitess        |
-|--------------------------|:------------------------------------------:|:----------------------------------------:|:----------------------:|:-------------:|:---------------------:|:----------------:|
-| Replication              |              Sync with Galera              |        Async and Group Replication       |          Async         |   Semi-sync   |   Group Replication   |     Async        |
-| Proxy                    |            HAProxy and ProxySQL            |         HAProxy and MySQL Router         |          None          |     None      |      MySQL Router     |     VTGate       |
-| Multi-cluster deployment |             :heavy_check_mark:             |              :no_entry_sign:             |     :no_entry_sign:    |:no_entry_sign:|     :no_entry_sign:   | :no_entry_sign:  |
-| Sharding                 |              :no_entry_sign:               |              :no_entry_sign:             |     :no_entry_sign:    |:no_entry_sign:|     :no_entry_sign:   |:heavy_check_mark:|
+| Feature/Product          | Percona Operator for MySQL  (based on PXC) | Percona Operator for MySQL (based on PS) | Bitpoke MySQL Operator |       Moco        | Oracle MySQL Operator |       Vitess       |
+| ------------------------ | :----------------------------------------: | :--------------------------------------: | :--------------------: | :---------------: | :-------------------: | :----------------: |
+| Replication              |              Sync with Galera              |       Async and Group Replication        |         Async          |     Semi-sync     |   Group Replication   |       Async        |
+| Proxy                    |            HAProxy and ProxySQL            |         HAProxy and MySQL Router         |          None          | Native kube-proxy |     MySQL Router      |       VTGate       |
+| Multi-cluster deployment |             :heavy_check_mark:             |             :no_entry_sign:              |    :no_entry_sign:     |  :no_entry_sign:  |    :no_entry_sign:    |  :no_entry_sign:   |
+| Sharding                 |              :no_entry_sign:               |             :no_entry_sign:              |    :no_entry_sign:     |  :no_entry_sign:  |    :no_entry_sign:    | :heavy_check_mark: |
 
 ## Backups
 
 Here are the backup and restore capabilities of each solution.
 
-| Feature/Product     | Percona Operator for MySQL  (based on PXC) | Percona Operator for MySQL (based on PS) | Bitpoke MySQL Operator |       Moco       | Oracle MySQL Operator |      Vitess      |
-|---------------------|:------------------------------------------:|:----------------------------------------:|:----------------------:|:----------------:|:---------------------:|:----------------:|
-| Scheduled backups   |             :heavy_check_mark:             |            :heavy_check_mark:            |   :heavy_check_mark:   |:heavy_check_mark:|     :no_entry_sign:   |:heavy_check_mark:|
-| Incremental backups |               :no_entry_sign:              |              :no_entry_sign:             |     :no_entry_sign:    |:heavy_check_mark:|     :no_entry_sign:   | :no_entry_sign:  |
-| PITR                |             :heavy_check_mark:             |            :heavy_check_mark:            |     :no_entry_sign:    | :no_entry_sign:  |     :no_entry_sign:   | :no_entry_sign:  |
-| PVCs for backups    |             :heavy_check_mark:             |              :no_entry_sign:             |     :no_entry_sign:    | :no_entry_sign:  |     :no_entry_sign:   | :no_entry_sign:  |
+| Feature/Product     | Percona Operator for MySQL  (based on PXC) | Percona Operator for MySQL (based on PS) | Bitpoke MySQL Operator |        Moco        | Oracle MySQL Operator |       Vitess       |
+| ------------------- | :----------------------------------------: | :--------------------------------------: | :--------------------: | :----------------: | :-------------------: | :----------------: |
+| Scheduled backups   |             :heavy_check_mark:             |            :heavy_check_mark:            |   :heavy_check_mark:   | :heavy_check_mark: |    :no_entry_sign:    | :heavy_check_mark: |
+| Incremental backups |              :no_entry_sign:               |             :no_entry_sign:              |    :no_entry_sign:     | :heavy_check_mark: |    :no_entry_sign:    |  :no_entry_sign:   |
+| PITR                |             :heavy_check_mark:             |            :heavy_check_mark:            |    :no_entry_sign:     | :heavy_check_mark: |    :no_entry_sign:    |  :no_entry_sign:   |
+| PVCs for backups    |             :heavy_check_mark:             |             :no_entry_sign:              |    :no_entry_sign:     |  :no_entry_sign:   |    :no_entry_sign:    |  :no_entry_sign:   |
 
 ## Monitoring
 
 Monitoring is crucial for any operations team.
 
-| Feature/Product    | Percona Operator for MySQL  (based on PXC) | Percona Operator for MySQL (based on PS) | Bitpoke MySQL Operator |       Moco      | Oracle MySQL Operator |     Vitess    |
-|--------------------|:------------------------------------------:|:----------------------------------------:|:----------------------:|:---------------:|:---------------------:|:-------------:|
-| Custom exporters   |              Through sidecars              |             Through sidecars             |     mysqld_exporter    | mysqld_exporter |     :no_entry_sign:   |:no_entry_sign:|
-| PMM                |             :heavy_check_mark:             |            :heavy_check_mark:            |     :no_entry_sign:    | :no_entry_sign: |     :no_entry_sign:   |:no_entry_sign:|
+| Feature/Product  | Percona Operator for MySQL  (based on PXC) | Percona Operator for MySQL (based on PS) | Bitpoke MySQL Operator |      Moco       | Oracle MySQL Operator |     Vitess      |
+| ---------------- | :----------------------------------------: | :--------------------------------------: | :--------------------: | :-------------: | :-------------------: | :-------------: |
+| Custom exporters |              Through sidecars              |             Through sidecars             |    mysqld_exporter     | mysqld_exporter |    :no_entry_sign:    | :no_entry_sign: |
+| PMM              |             :heavy_check_mark:             |            :heavy_check_mark:            |    :no_entry_sign:     | :no_entry_sign: |    :no_entry_sign:    | :no_entry_sign: |
 
 ## Miscellaneous
 
 Compare various features that are not a good fit for other categories.
 
-| Feature/Product      | Percona Operator for MySQL  (based on PXC) | Percona Operator for MySQL (based on PS) | Bitpoke MySQL Operator |       Moco       | Oracle MySQL Operator |      Vitess      |
-|----------------------|:------------------------------------------:|:----------------------------------------:|:----------------------:|:----------------:|:---------------------:|:----------------:|
-| Customize MySQL      |           ConfigMaps and Secrets           |          ConfigMaps and Secrets          |       ConfigMaps       |    ConfigMaps    |      ConfigMaps       | :no_entry_sign:  |
-| Helm                 |             :heavy_check_mark:             |            :heavy_check_mark:            |   :heavy_check_mark:   |:heavy_check_mark:|  :heavy_check_mark:   | :no_entry_sign:  |
-| Transport encryption |             :heavy_check_mark:             |            :heavy_check_mark:            |     :no_entry_sign:    | :no_entry_sign:  |  :heavy_check_mark:   |:heavy_check_mark:|
-| Encryption-at-rest   |             :heavy_check_mark:             |            :heavy_check_mark:            |     :no_entry_sign:    | :no_entry_sign:  |     :no_entry_sign:   | :no_entry_sign:  |
+| Feature/Product      | Percona Operator for MySQL  (based on PXC) | Percona Operator for MySQL (based on PS) | Bitpoke MySQL Operator |        Moco        | Oracle MySQL Operator |       Vitess       |
+| -------------------- | :----------------------------------------: | :--------------------------------------: | :--------------------: | :----------------: | :-------------------: | :----------------: |
+| Customize MySQL      |           ConfigMaps and Secrets           |          ConfigMaps and Secrets          |       ConfigMaps       |     ConfigMaps     |      ConfigMaps       |  :no_entry_sign:   |
+| Helm                 |             :heavy_check_mark:             |            :heavy_check_mark:            |   :heavy_check_mark:   | :heavy_check_mark: |  :heavy_check_mark:   |  :no_entry_sign:   |
+| Transport encryption |             :heavy_check_mark:             |            :heavy_check_mark:            |    :no_entry_sign:     |  :no_entry_sign:   |  :heavy_check_mark:   | :heavy_check_mark: |
+| Encryption-at-rest   |             :heavy_check_mark:             |            :heavy_check_mark:            |    :no_entry_sign:     |  :no_entry_sign:   |    :no_entry_sign:    |  :no_entry_sign:   |


### PR DESCRIPTION
I'm an author of MOCO, a MySQL operator.
Let me correct some of the items.

- MOCO is tested for the latest 3 versions of Kubernetes.
- MOCO does not continuously take backup of binlog, but it can restore at a point-in-time with dumped binlogs.
- MOCO uses Kubernetes' native proxy feature (kube-proxy).