### PR TITLE
Update constraints.md

### DIFF
--- a/docs/constraints.md
+++ b/docs/constraints.md
@@ -49,10 +49,10 @@ may have one of the following values:
 
 * `kubernetes.io/hostname` - Pods will avoid residing within the same host,
 
-* `failure-domain.beta.kubernetes.io/zone` - Pods will avoid residing
+* `topology.kubernetes.io/zone` - Pods will avoid residing
     within the same zone,
 
-* `failure-domain.beta.kubernetes.io/region` - Pods will avoid
+* `topology.kubernetes.io/region` - Pods will avoid
     residing within the same region,
 
 * `none` - no constraints are applied.
@@ -85,7 +85,7 @@ affinity:
              operator: In
              values:
              - S1
-         topologyKey: failure-domain.beta.kubernetes.io/zone
+         topologyKey: topology.kubernetes.io/zone
      podAntiAffinity:
        preferredDuringSchedulingIgnoredDuringExecution:
        - weight: 100
@@ -117,7 +117,7 @@ affinity:
 ```
 
 See explanation of the advanced affinity options [in Kubernetes
-documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity-beta-feature).
+documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).
 
 ## Tolerations
 


### PR DESCRIPTION
Use `topology.kubernetes.io/zone` and region instead of deprecated (since v1.17, which nobody should be running) `failure-domain.beta.kubernetes.io/zone` 

See https://kubernetes.io/docs/reference/labels-annotations-taints/#failure-domainbetakubernetesioregion