### PR TITLE
Update connectivity.txt

### DIFF
--- a/docs/assets/fragments/connectivity.txt
+++ b/docs/assets/fragments/connectivity.txt
@@ -6,7 +6,7 @@
     user:
     
     ``` {.bash data-prompt="$" }
-    $ kubectl get secrets cluster1-secrets -o yaml -o jsonpath='{.data.root}' | base64 --decode | tr '\n' ' ' && echo " "
+    $ kubectl get secret cluster1-secrets -o jsonpath='{.data.root}' | base64 --decode && echo
     ```
 
 2. Run a container with `mysql` tool and connect its console output to your
@@ -26,10 +26,10 @@
 
     === "with HAProxy (default)"
         ```{.bash data-prompt="$"}
-        $ mysql -h cluster1-haproxy -uroot -proot_password
+        $ mysql -h cluster1-haproxy -uroot -p<root_password>
         ```
 
     === "with ProxySQL"
         ```{.bash data-prompt="$"}
-        $ mysql -h cluster1-proxysql -uroot -proot_password
+        $ mysql -h cluster1-proxysql -uroot -p<root_password>
         ```


### PR DESCRIPTION
I added two changes:

1. Sending a better version for the first command: Using a more direct output format to avoid unnecessary transformations. Give the same result.
**Previous**:
`kubectl get secrets cluster1-secrets -o yaml -o jsonpath='{.data.root}' | base64 --decode | tr '\n' ' ' && echo " "`
**Proposal**:
`kubectl get secret cluster1-secrets -o jsonpath='{.data.root}' | base64 --decode && echo`

2. In the second command, I am indicating that <root_password> is a parameter. This may be understood by many, but not by those who just want to test the operator. This may be understood by many, but not by those who just want to test the operator.
**Previous**:
`mysql -h cluster1-haproxy -uroot -proot_password`
**Proposal**:
`mysql -h cluster1-haproxy -uroot -p<root_password>`

I tested them, and any works fine!