### PR TITLE
Fix issue number (K8SPXC-1335 -> K8SPXC-1339)

### DIFF
--- a/docs/ReleaseNotes/Kubernetes-Operator-for-PXC-RN1.14.0.md
+++ b/docs/ReleaseNotes/Kubernetes-Operator-for-PXC-RN1.14.0.md
@@ -59,7 +59,7 @@ Kubernetes supports the Persistent Volume expansion as a stable feature since v1
 * {{ k8spxcjira(1302) }}: Fix a bug where the Operator was continuously trying to delete a backup from an S3 bucket that has a retention policy configured and `delete-s3-backup` finalizer present, which could cause out-of-memory issue in case of tight Pod’s memory limits
 * {{ k8spxcjira(1333) }}: Scheduled backup was failing if Percona XtraDB Cluster name was not unique across namespaces
 * {{ k8spxcjira(1335) }}: Fix a bug where HAProxy was not stopping existing connections to primary in case of Percona XtraDB Cluster instance failover but only routed new ones to another instance
-* {{ k8spxcjira(1335) }}: Fix a bug where HAProxy was not aware of the IP address change in case of the restarted Percona XtraDB Cluster Pod and couldn't reach it until the DNS cache update
+* {{ k8spxcjira(1339) }}: Fix a bug where HAProxy was not aware of the IP address change in case of the restarted Percona XtraDB Cluster Pod and couldn't reach it until the DNS cache update
 * {{ k8spxcjira(1345) }}: Fix a regression where the Operator was unable to customize readinessProbe of the pxc container
 * {{ k8spxcjira(1350) }}: Fix a bug due to which log rotate could cause locking TOI ([Total Order Isolation](https://galeracluster.com/library/documentation/schema-upgrades.html#toi)) DDL operation on the cluster with flush error logs, resulting in unnecessary synchronization on the whole cluster and possible warnings in logs
 


### PR DESCRIPTION
In the bugs-fixed section (in 1.14.0 release notes), K8SPXC-1335 is listed twice. The second one should be K8SPXC-1339 in my opinion.