### PR TITLE
fix: s3 backup options

### DIFF
--- a/docs/operator.md
+++ b/docs/operator.md
@@ -1377,12 +1377,12 @@ file contains the following configuration options for the regular Percona XtraDB
 | **Example**     | |
 | **Description** | The [Amazon S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html) name for backups |
 |                 | |
-| **Key**         | {{ optionlink('backup.storages.s3.&lt;storage-name&gt;.region') }} |
+| **Key**         | {{ optionlink('backup.storages.&lt;storage-name&gt;.s3.region') }} |
 | **Value**       | string |
 | **Example**     | `us-east-1` |
 | **Description** | The [AWS region](https://docs.aws.amazon.com/general/latest/gr/rande.html) to use. Please note **this option is mandatory** for Amazon and all S3-compatible storages |
 |                 | |
-| **Key**         | {{ optionlink('backup.storages.s3.&lt;storage-name&gt;.endpointUrl') }} |
+| **Key**         | {{ optionlink('backup.storages.&lt;storage-name&gt;.s3.endpointUrl') }} |
 | **Value**       | string |
 | **Example**     | |
 | **Description** | The endpoint URL of the S3-compatible storage to be used (not needed for the original Amazon S3 cloud) |


### PR DESCRIPTION
I have noticed that s3 backup docs section has wrong keys order for `region` and `endpointUrl`.


Also [restore page](https://docs.percona.com/percona-operator-for-mysql/pxc/backups-restore.html#restore-the-cluster-without-point-in-time-recovery) shows example with `spec.storageName` field, but it is wrong and operator throws error. In accordance with docs it should be `backupSource.storageName` and it works fine.
If you wish i can replace `storageName` with `backupSource.storageName` on this page.