### PR TITLE
Update users.md

### DIFF
--- a/docs/users.md
+++ b/docs/users.md
@@ -16,7 +16,8 @@ There are no unprivileged (general purpose) user accounts created by
 default. If you need general purpose users, please run commands below:
 
 ``` {.bash data-prompt="$" data-prompt-second="mysql>"}
-$ kubectl run -it --rm percona-client --image=percona:8.0 --restart=Never -- mysql -hcluster1-pxc -uroot -proot_password
+MYPASS=`kubectl get secrets cluster1-secrets -o yaml|grep "root:"|awk -F": " '{print $2}'| base64 -d`
+$ kubectl run -it --rm percona-client --image=percona:8.0 --restart=Never -- mysql -hcluster1-pxc -uroot -p$MYPASS
 mysql> GRANT ALL PRIVILEGES ON database1.* TO 'user1'@'%' IDENTIFIED BY 'password1';
 ```
 


### PR DESCRIPTION
The MySQL root password is no longer available as an environment variable inside the container. I provide a two-step approach that consists in grabbing the password from the secrets file first and storing it in a local env; maybe we want to provide a more detailed explanation instead.