### PR TITLE
TLS docs: clarify renewal requirement for default option, fix resource name

### DIFF
--- a/docs/TLS.md
+++ b/docs/TLS.md
@@ -10,9 +10,10 @@ Security (TLS) cryptographic protocol for the following types of communication:
 
 The internal certificate is also used as an authorization method.
 
-TLS security can be configured in several ways. By default, the Operator
-generates long-term certificates automatically if there are no certificate
-secrets available. Other options are the following ones:
+TLS security can be configured in several ways:
+
+* The Operator generates long-term certificates automatically if there are no
+certificate secrets available (default option, and requires you renew them manually),
 
 * The Operator can use a specifically installed *cert-manager*, which will
 automatically generate and renew short-term TLS certificates,
@@ -92,7 +93,7 @@ The set of commands generate certificates with the following attributes:
 
 You should generate certificates twice: one set is for external communications,
 and another set is for internal ones. A secret created for the external use must
-be added to `cr.yaml/spec/secretsName`. A certificate generated for internal
+be added to `cr.yaml/spec/sslSecretName`. A certificate generated for internal
 communications must be added to the `cr.yaml/spec/sslInternalSecretName`.
 
 ``` {.bash data-prompt="$" }


### PR DESCRIPTION
Today I found out it's my cluster 1 year anniversary since the certificates created by the operator expired  😄 

With this PR I'm suggesting to make this rotation requirement more clear to avoid my mistake (assuming that certificates created automatically will be managed automatically).
This also fixes the resource name used for external certificates, from `secretsName` (which is used for passwords) to `sslSecretName`.