### PR TITLE
Update delete.md, adding finalizer `delete-pxc-pods-in-order`

### DIFF
--- a/docs/delete.md
+++ b/docs/delete.md
@@ -13,13 +13,14 @@ To delete the database cluster means to delete the Custom Resource associated wi
 
 !!! note
 
-    There are 3 [finalizers :octicons-link-external-16:](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers) defined in the Custom Resource, which define whether to delete or preserve  TLS-related objects and data volumes when the cluster is deleted.
+    There are 4 [finalizers :octicons-link-external-16:](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers) defined in the Custom Resource, which define whether to delete or preserve  TLS-related objects and data volumes when the cluster is deleted.
 
-    * `finalizers.percona.com/delete-ssl`: if present, objects, created for SSL (Secret, certificate, and issuer) are deleted along with the cluster deletion.
+    * `finalizers.percona.com/delete-pxc-pods-in-order`: if present, PXC pods are deleted in order on cluster deletion (will not delete PVC).
+    * `finalizers.percona.com/delete-ssl`: if present, objects, created for SSL (Secret, certificate, and issuer) are deleted along with the cluster deletion (will not delete PVC).
     * `finalizers.percona.com/delete-pxc-pvc`: if present, [Persistent Volume Claims :octicons-link-external-16:](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) for the database cluster Pods are deleted along with the cluster deletion.
     * `finalizers.percona.com/delete-proxysql-pvc`: if present, [Persistent Volume Claims :octicons-link-external-16:](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) for ProxySQL Pods are deleted along with the cluster deletion.
 
-    All 3 finalizers are off by default in the `deploy/cr.yaml` configuration file, and this allows you to recreate the cluster without losing data, credentials for the system users, etc. You can always [delete TLS-related objects and PVCs manually](#clean-up-resources), if needed. 
+    The default finalizer in `deploy/cr.yaml` configuration file is `finalizers.percona.com/delete-pxc-pods-in-order`, this allows you to recreate the cluster without losing data, credentials for the system users, etc. You can always [delete TLS-related objects and PVCs manually](#clean-up-resources), if needed. 
 
 The steps are the following:
 {.power-number}


### PR DESCRIPTION
The doc is missing `finalizers.percona.com/delete-pxc-pods-in-order`.  This is the default `finalizer` as of `pxc-db` version `1.18.0`: 
- https://artifacthub.io/packages/helm/percona/pxc-db/?modal=values
- https://github.com/percona/percona-xtradb-cluster-operator/blob/main/deploy/cr.yaml